### PR TITLE
Fix Update Conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "nyholm/psr7": "^1.3",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
-        "symfony/options-resolver": "^2.6 || ^3.4 || ^4.4 || ^5.0"
+        "symfony/options-resolver": "^2.6 || ^3.4 || ^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.2",


### PR DESCRIPTION
symfony/options-resolver is available in 6.0 which is required by the latest symfony builds